### PR TITLE
privacypolicy docs link fixed

### DIFF
--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -130,7 +130,8 @@
 
     <ul>
       <li>
-        Visit our website at https://stonecss.com, or any website of ours that links to this privacy notice
+        Visit our website at <a href="https://stonecss.com">https://stonecss.com</a>, 
+ or any website of ours that links to this privacy notice
 
       </li>
       <li>
@@ -140,7 +141,8 @@
 
     <p>Questions or concerns? Reading this privacy notice will help you understand your privacy rights and choices. If
       you do not agree with our policies and practices, please do not use our Services. If you still have any questions
-      or concerns, please contact us at devarshishimpi@gmail.com.</p>
+      or concerns, please contact us at <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com.</a>  
+</p>
 
     <h2>
       <hr>
@@ -197,7 +199,7 @@
 
     <p>
       <b>How do you exercise your rights?</b> The easiest way to exercise your rights is by filling out our data subject
-      request form available here: devarshishimpi@gmail.com, or by contacting us. We will consider and act upon any
+      request form available here: <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a>, or by contacting us. We will consider and act upon any
       request in accordance with applicable data protection laws.
     </p>
 
@@ -454,7 +456,7 @@
       still communicate with you — for example, to send you service-related messages that are necessary for the
       administration and use of your account, to respond to service requests, or for other non-marketing purposes.</p>
     <b>
-      If you have questions or comments about your privacy rights, you may email us at devarshishimpi@gmail.com.</b>
+      If you have questions or comments about your privacy rights, you may email us at <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a>.</b>
 
     <hr>
 
@@ -599,7 +601,7 @@
     <h2 id="">How do we use and share your personal information?</h2>
 
     <p>More information about our data collection and sharing practices can be found in this privacy notice.</p>
-    <p>You may contact us by email at devarshishimpi@gmail.com, The contact form in the website, or by referring to the
+    <p>You may contact us by email at <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a>, The contact form in the website, or by referring to the
       contact details at the bottom of this document.</p>
     <p>If you are using an authorized agent to exercise your right to opt out we may deny a request if the authorized
       agent does not submit proof that they have been validly authorized to act on your behalf.</p>
@@ -661,7 +663,7 @@
     <p>You may request to opt out from future selling of your personal information to third parties. Upon receiving an
       opt-out request, we will act upon the request as soon as feasibly possible, but no later than fifteen (15) days
       from the date of the request submission.</p>
-    <p>To exercise these rights, you can contact us by email at devarshishimpi@gmail.com, The contact form in the
+    <p>To exercise these rights, you can contact us by email at <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a>, The contact form in the
       website, or by referring to the contact details at the bottom of this document. If you have a complaint about how
       we handle your data, we would like to hear from you.</p>
     <hr>
@@ -674,20 +676,20 @@
       protecting your information.</p>
     <hr>
     <h2 id="toc12">HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</h2>
-    <p>If you have questions or comments about this notice, you may email us at devarshishimpi@gmail.com or by post to:
+    <p>If you have questions or comments about this notice, you may email us at <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a> or by post to:
     </p>
 
     <p>StoneCSS<br />
       Mumbai, Maharashtra<br />
       India<br />
-      devarshishimpi@gmail.com<br /><br />
+      <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a><br /><br />
 
 
       <hr>
     <h2 id="toc13">HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?</h2>
     <p>Based on the applicable laws of your country, you may have the right to request access to the personal
       information we collect from you, change that information, or delete it. To request to review, update, or delete
-      your personal information, please visit: devarshishimpi@gmail.com.</p>
+      your personal information, please visit: <a href="mailto:devarshishimpi@gmail.com">devarshishimpi@gmail.com</a>.</p>
     <hr>
 
     <h2>Thank You</h2>


### PR DESCRIPTION
Signed-off-by: Prakash <gatiyalap@gmail.com>

## Describe your changes
I have made website and email link clickable in privacypolicy docs(https://stonecss.com/privacypolicy.html)
Now website link is clickable and by clicking on email link, It will open email app.
## Screenshots - If Any (Optional)
![image](https://user-images.githubusercontent.com/34413515/196003188-a4027f37-32a7-4647-8195-4e744206c634.png)
![image](https://user-images.githubusercontent.com/34413515/196003200-25e0cbad-8c6f-45ec-94c0-48faee254fcb.png)

## Issue ticket number and link - If Any
https://github.com/devarshishimpi/stonecss/issues/63
## Checklist before requesting a review

- [X] I have performed a self-review of my code.

- [X] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).

- [X] I ran the app and tested it locally to verify that it works as expected.

- [X] I have starred the repository.

## Additional Information (Optional)